### PR TITLE
Fix the noun project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Artwork by [Vitaliy Gorbachev][7]
 [3]:	http://cocoadocs.org/docsets/Peek
 [4]:	http://cocoapods.org/pods/Peek
 [5]:	http://twitter.com/shaps "Shaps on Twitter"
-[6]:	www.thenounproject.com
+[6]:	https://thenounproject.com
 [7]:	https://thenounproject.com/vitalikexpert
 
 [image-1]:	https://img.shields.io/cocoapods/v/Peek.svg?style=flat


### PR DESCRIPTION
Previously the link pointed to `https://github.com/shaps80/Peek/blob/master/www.thenounproject.com` instead of `thenounproject.com` because you didn't specify the protocol. I don't know why GitHub is handling these links this way.