### PR TITLE
Uses more succinct force unwrap instead of guard with fatalError

### DIFF
--- a/Pod/Classes/Controllers & Views/PeekSectionedViewController.swift
+++ b/Pod/Classes/Controllers & Views/PeekSectionedViewController.swift
@@ -44,7 +44,7 @@ internal class PeekSectionedViewController: UIViewController, UITableViewDelegat
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "InspectorCell", for: indexPath) as? PeekInspectorCell else { fatalError() }
+        let cell = tableView.dequeueReusableCell(withIdentifier: "InspectorCell", for: indexPath) as! PeekInspectorCell
         
         cell.detailTextLabel?.font = UIFont.preferredFont(forTextStyle: .body)
         cell.detailTextLabel?.textColor = peek.options.theme.primaryTextColor
@@ -62,7 +62,7 @@ internal class PeekSectionedViewController: UIViewController, UITableViewDelegat
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: "CollapsibleSectionHeaderView") as? CollapsibleSectionHeaderView else { fatalError() }
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: "CollapsibleSectionHeaderView") as! CollapsibleSectionHeaderView
         header.contentView.backgroundColor = peek.options.theme.backgroundColor
         header.label.text = sectionTitle(for: section)
         header.label.font = UIFont.systemFont(ofSize: 15, weight: .black)


### PR DESCRIPTION
Failing force unwrap means exact fatalError and is more succinct.

# Base Branch

Make sure you're currently pointing to the next release base branch. For example:

`branch: release/5.1.0`

If you're unsure, check the latest tag, it'll be a semantic version higher than that.

# SwiftLint 

Ensure SwiftLint hasn't reported any issues. Code styles must be adhered to.

# README

Does the README need updating? Ensure anything relevant is updated there as well.
