### PR TITLE
Update enum cases for iOS 13 support

### DIFF
--- a/Pod/Classes/Helpers/Enum+Descriptions.swift
+++ b/Pod/Classes/Helpers/Enum+Descriptions.swift
@@ -151,6 +151,8 @@ extension UIActivityIndicatorView.Style: PeekDescribing {
         case .gray: return "Small Gray"
         case .white: return "Small White"
         case .whiteLarge: return "Large White"
+        case .medium: return "Medium"
+        case .large: return "Large"
         }
     }
     
@@ -209,6 +211,7 @@ extension UIBarButtonItem.SystemItem: PeekDescribing {
         case .stop: return "Stop"
         case .trash: return "Trash"
         case .undo: return "Undo"
+        case .close: return "Close"
         }
     }
     
@@ -342,6 +345,7 @@ extension UIModalPresentationStyle: PeekDescribing {
         case .pageSheet: return "Page Sheet"
         case .popover: return "Popover"
         case .blurOverFullScreen: return "Blur Over Full Screen"
+        case .automatic: return "Automatic"
         }
     }
     
@@ -386,6 +390,7 @@ extension UIButton.ButtonType: PeekDescribing {
         case .infoLight: return "Info Light"
         case .system: return "System"
         case .plain: return "Plain"
+        case .close: return "Close"
         }
     }
     


### PR DESCRIPTION
### Context of this PR
With iOS 13 coming up, this PR updates the enum cases in the Enum+Descriptions.swift file. The extensions that are updated for iOS 13:

1. UIActivityIndicatorView.Style -> medium, large
2. UIBarButtonItem.SystemItem -> close
3. UIModalPresentationStyle -> automatic
4. UIButton.ButtonType -> close
